### PR TITLE
Use a qualified import for GHC 8.2 compatibility

### DIFF
--- a/src/Data/Either/Located.hs
+++ b/src/Data/Either/Located.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE FlexibleContexts #-}
 module Data.Either.Located
-  ( module Data.Either
+  ( module E
   , fromRight, fromLeft
   ) where
 
-import Data.Either
+import qualified Data.Either as E
 import qualified GHC.Err.Located as L
 
 fromRight :: L.HasCallStack


### PR DESCRIPTION
It looks like Data.Either exports its own fromLeft and fromRight as of the base
included in 8.2